### PR TITLE
docs: Fix KAFKA_OPTS configuration to match E2E test implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Add the following to your Kafka startup script or `KAFKA_OPTS`:
 
 ```bash
 export CLASSPATH="/path/to/kafka-ssl-jfr-1.1.0.jar:$CLASSPATH"
-export KAFKA_OPTS="-javaagent:/path/to/jmc-agent.jar=/path/to/kafka-ssl-jfr.xml"
+export KAFKA_OPTS="-XX:StartFlightRecording=name=SSLCapture,filename=/path/to/kafka-ssl.jfr,maxsize=100m,dumponexit=true -javaagent:/path/to/jmc-agent.jar=/path/to/kafka-ssl-jfr.xml"
 
 bin/kafka-server-start.sh config/server.properties
 ```
@@ -87,17 +87,18 @@ When the broker starts, JMC Agent will:
 After clients connect, view the captured SNI events:
 
 ```bash
-# View all SSL handshake events
-jfr print --events kafka.ssl.Handshake /path/to/recording.jfr
-
-# Export to JSON
-jfr print --json --events kafka.ssl.Handshake /path/to/recording.jfr > ssl-events.json
-
 # Check active recording
 jcmd <broker-pid> JFR.check
 
-# Dump recording from running broker
-jcmd <broker-pid> JFR.dump name=agent-main filename=kafka-ssl.jfr
+# Dump recording from running broker (optional - only if you need events before shutdown)
+jcmd <broker-pid> JFR.dump name=SSLCapture filename=/path/to/kafka-ssl-dump.jfr
+
+# After broker shutdown, the JFR file is written automatically (dumponexit=true)
+# View all SSL handshake events
+jfr print --events kafka.ssl.Handshake /path/to/kafka-ssl.jfr
+
+# Export to JSON
+jfr print --json --events kafka.ssl.Handshake /path/to/kafka-ssl.jfr > ssl-events.json
 ```
 
 ### Example Event Output


### PR DESCRIPTION
## Summary

Fix documentation inconsistencies in `KAFKA_OPTS` configuration between README.md, MANUAL-KAFKA-TEST.md, and the actual E2E test implementation (KafkaJMCAgentE2ETest.java).

## Changes

- ✅ Add JFR recording parameters to `KAFKA_OPTS` with named recording (`name=SSLCapture`)
- ✅ Include `filename`, `maxsize`, and `dumponexit` options
- ✅ Update JFR dump instructions to use correct recording name
- ✅ Fix broken workflow where JFR file path was not specified
- ✅ Ensure consistent file paths across all examples

## Problem Fixed

Previously, README.md instructed users to analyze JFR files at `/path/to/recording.jfr`, but the `KAFKA_OPTS` configuration didn't specify where to write the JFR file. This created a broken workflow where the expected file wouldn't exist.

## Test Plan

- [x] Verified changes match KafkaJMCAgentE2ETest.java implementation (lines 136-141, 286-287)
- [x] All file paths are now consistent across documentation
- [x] Instructions now include both live dump and shutdown dump options

🤖 Generated with [Claude Code](https://claude.com/claude-code)